### PR TITLE
Some minor fixes to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 # Install packages
 
-sudo pacman -S xorg-server xorg-xinit qtile alacritty libwebp wget feh
+sudo pacman -S --needed xorg-server xorg-xinit qtile alacritty libwebp wget feh
 yay -S picom-jonaburg-git starship
 
 pushd slock
@@ -12,6 +12,16 @@ popd
 # Install font
 
 wget https://github.com/ryanoasis/nerd-fonts/blob/e90d082ffc20567093b3d8448e0142f02e996b45/patched-fonts/FiraCode/Regular/complete/Fira%20Code%20Regular%20Nerd%20Font%20Complete.ttf
+
+# Check if directories exists, otherwise create them
+if [ ! -d "$HOME/.local/share/fonts" ]; then
+    mkdir -p $HOME/.local/share/fonts
+fi
+
+if [ ! -d "$HOME/.config" ]; then
+    mkdir -p $HOME/.config
+fi
+
 mv Fira\ Code\ Regular\ Nerd\ Font\ Complete.ttf $HOME/.local/share/fonts/FiraCodeNerdFont.ttf
 fc-cache
 


### PR DESCRIPTION
Added a check for existing directories, if it does not exist, it should create one, otherwise the script would fail to move the font file to the target directory. Also consider using `--needed` for package installation, because sometimes (rarely) re-installing existing packages mess up some configuration files.